### PR TITLE
Added output configurability

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -133,6 +133,14 @@ module.exports = {
         const entry = Object.assign(
             { index: indexEntry }, appConfig.entry
         );
+        const output = Object.assign(
+            {
+                path: paths.appBuild,
+                filename: dev ? '[name].js' : '[name].[chunkhash].js',
+                publicPath: ''
+            },
+            appConfig.output
+        );
 
         return {
             devtool: dev ? 'eval-source-map' : 'source-map',
@@ -140,11 +148,7 @@ module.exports = {
 
             entry: entry,
 
-            output: {
-                path: paths.appBuild,
-                filename: dev ? '[name].js' : '[name].[chunkhash].js',
-                publicPath: '/'
-            },
+            output: output,
 
             module: {
                 rules: [


### PR DESCRIPTION
This ended up being the only hard requirement for the project I'm spinning up with this stack at the moment.

Need to be able to set the `output.publicPath` to tell the html-webpack-plugin to render all refs as relatives rather than absolutes to allow for base tag to dictate the nested app's folder location.

Will add empty output object to `build.config.js` file in the `front-end-stack` project to match this if we decide it's a goer.

@teriu - Obviously open for Monday morning discussion over coffee...  😉   ☕